### PR TITLE
Add the feature to destory the lanched MapR cluster in GCE

### DIFF
--- a/remove-mapr-cluster.sh
+++ b/remove-mapr-cluster.sh
@@ -122,7 +122,6 @@ if [ -n "${pdisk:-}" ] ; then
 		echo " Delete persistent data volumes (pdisk)"
 		delete_persistent_data_disks $host
 	fi
-
 done
 
 wait


### PR DESCRIPTION
--config-file --persistent-disks --node-name should be consistent with  the ones that launch script used.
